### PR TITLE
Update lsusb.c

### DIFF
--- a/lsusb.c
+++ b/lsusb.c
@@ -2373,7 +2373,7 @@ static void dump_videostreaming_interface(const unsigned char *buf)
 			printf("Random pattern of fields 1 and 2\n");
 			break;
 		}
-		printf("          bCopyProtect                  %5u\n", buf[26]);
+		printf("        bCopyProtect                  %5u\n", buf[26]);
 		if (buf[2] == 0x10)
 			printf("          bVariableSize                 %5u\n", buf[27]);
 		dump_junk(buf, "        ", len);
@@ -2477,7 +2477,7 @@ static void dump_videostreaming_interface(const unsigned char *buf)
 			printf("Random pattern of fields 1 and 2\n");
 			break;
 		}
-		printf("          bCopyProtect                  %5u\n", buf[10]);
+		printf("        bCopyProtect                  %5u\n", buf[10]);
 		dump_junk(buf, "        ", 11);
 		break;
 


### PR DESCRIPTION
Very minor UVC Frame descriptor formatting change.

bCopyProtect is a subfield of the frame descriptor, and is not a property of the preceding bit map. Just unindenting it two spaces to accurately reflect this.